### PR TITLE
feat: add pdf support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Simple OpenOffice conversion Docker Image
 
-Simple docker image to have a REST api to convert docs from doc to docx using openoffice.
+Simple docker image to have a REST api to convert various Office document formats using LibreOffice.
 
 ## Build
 
@@ -21,7 +21,17 @@ POST /doc-to-docx
 Content-Type: multipart/form-data
 file=@document.doc
 
-### Convert DOCX to PDF
-POST /docx-to-pdf
+### Convert to PDF (from DOCX or PPTX)
+POST /to-pdf
 Content-Type: multipart/form-data
-file=@document.docx
+file=@document.docx or file=@presentation.pptx
+
+### Convert PPT to PPTX
+POST /ppt-to-pptx
+Content-Type: multipart/form-data
+file=@presentation.ppt
+
+### Convert XLS to XLSX
+POST /xls-to-xlsx
+Content-Type: multipart/form-data
+file=@spreadsheet.xls

--- a/README.md
+++ b/README.md
@@ -13,3 +13,15 @@ docker build -t libreoffice-rest:latest .
 ```
 docker run -p 8080:8080 -e TARGET_DIR=/tmp libreoffice-rest:latest
 ```
+
+## API Usage
+
+### Convert DOC to DOCX
+POST /doc-to-docx
+Content-Type: multipart/form-data
+file=@document.doc
+
+### Convert DOCX to PDF
+POST /docx-to-pdf
+Content-Type: multipart/form-data
+file=@document.docx

--- a/src/openoffice/libreoffice-service.ts
+++ b/src/openoffice/libreoffice-service.ts
@@ -84,6 +84,26 @@ class LibreOfficeService {
     return outputPath;
   }
 
+  public async docxToPdf(filename: string): Promise<string> {
+    await this.ensureServiceRunning();
+  
+    const cwd = pathUtils.dirname(filename);
+    const basename = pathUtils.basename(filename, '.docx');
+    const outputPath = pathUtils.join(cwd, `${basename}.pdf`);
+  
+    await spawnPromise(
+      "unoconvert",
+      ["--port", UNOSERVER_PORT, "--convert-to", "pdf", filename, outputPath],
+      {
+        cwd,
+        timeout: 120_000,
+        env: process.env,
+      }
+    );
+  
+    return outputPath;
+  }
+
   public async shutdown(): Promise<void> {
     if (this.serverProcess) {
       this.serverProcess.kill();
@@ -98,4 +118,8 @@ export const libreOfficeService = LibreOfficeService.getInstance();
 // Export the conversion function as before
 export async function docToDocx(filename: string): Promise<string> {
   return libreOfficeService.docToDocx(filename);
+}
+
+export async function docxToPdf(filename: string): Promise<string> {
+  return libreOfficeService.docxToPdf(filename);
 }

--- a/src/openoffice/libreoffice-service.ts
+++ b/src/openoffice/libreoffice-service.ts
@@ -104,6 +104,64 @@ class LibreOfficeService {
     return outputPath;
   }
 
+  public async pptxToPdf(filename: string): Promise<string> {
+    await this.ensureServiceRunning();
+  
+    const cwd = pathUtils.dirname(filename);
+    const basename = pathUtils.basename(filename, '.pptx');
+    const outputPath = pathUtils.join(cwd, `${basename}.pdf`);
+  
+    await spawnPromise(
+      "unoconvert",
+      ["--port", UNOSERVER_PORT, "--convert-to", "pdf", filename, outputPath],
+      {
+        cwd,
+        timeout: 120_000,
+        env: process.env,
+      }
+    );
+  
+    return outputPath;
+  }
+
+  public async pptToPptx(filename: string): Promise<string> {
+    await this.ensureServiceRunning();
+
+    const cwd = pathUtils.dirname(filename);
+    const outputPath = filename + "x";
+
+    await spawnPromise(
+      "unoconvert",
+      ["--port", UNOSERVER_PORT, "--convert-to", "pptx", filename, outputPath],
+      {
+        cwd,
+        timeout: 120_000,
+        env: process.env,
+      }
+    );
+
+    return outputPath;
+  }
+
+  public async xlsToXlsx(filename: string): Promise<string> {
+    await this.ensureServiceRunning();
+
+    const cwd = pathUtils.dirname(filename);
+    const outputPath = filename + "x";
+
+    await spawnPromise(
+      "unoconvert",
+      ["--port", UNOSERVER_PORT, "--convert-to", "xlsx", filename, outputPath],
+      {
+        cwd,
+        timeout: 120_000,
+        env: process.env,
+      }
+    );
+
+    return outputPath;
+  }
+
   public async shutdown(): Promise<void> {
     if (this.serverProcess) {
       this.serverProcess.kill();
@@ -115,11 +173,23 @@ class LibreOfficeService {
 // Export a singleton instance
 export const libreOfficeService = LibreOfficeService.getInstance();
 
-// Export the conversion function as before
+// Export the conversion functions
 export async function docToDocx(filename: string): Promise<string> {
   return libreOfficeService.docToDocx(filename);
 }
 
 export async function docxToPdf(filename: string): Promise<string> {
   return libreOfficeService.docxToPdf(filename);
+}
+
+export async function pptxToPdf(filename: string): Promise<string> {
+  return libreOfficeService.pptxToPdf(filename);
+}
+
+export async function pptToPptx(filename: string): Promise<string> {
+  return libreOfficeService.pptToPptx(filename);
+}
+
+export async function xlsToXlsx(filename: string): Promise<string> {
+  return libreOfficeService.xlsToXlsx(filename);
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -12,6 +12,9 @@ import fastifyPrometheus from "./prometheus/plugin";
 import {
   docToDocx,
   docxToPdf,
+  pptxToPdf,
+  pptToPptx,
+  xlsToXlsx,
   libreOfficeService,
 } from "./openoffice/libreoffice-service";
 
@@ -123,7 +126,7 @@ export async function start() {
     }
   });
 
-  app.post("/docx-to-pdf", {}, async (req, reply) => {
+  app.post("/to-pdf", {}, async (req, reply) => {
     if (!req.isMultipart) {
       return reply.status(400).send({
         error: "Not a multipart request",
@@ -137,24 +140,135 @@ export async function start() {
       });
     }
   
-    const targetFilepath = pathUtils.join(TARGET_DIR, `${Date.now()}.docx`);
+    let fileExt = "";
+    let convertFn;
+    const mimetype = data.mimetype;
+    
+    if (mimetype === "application/vnd.openxmlformats-officedocument.wordprocessingml.document") {
+      fileExt = ".docx";
+      convertFn = docxToPdf;
+    } else if (mimetype === "application/vnd.openxmlformats-officedocument.presentationml.presentation") {
+      fileExt = ".pptx";
+      convertFn = pptxToPdf;
+    } else {
+      return reply.status(400).send({
+        error: "File must be of type docx or pptx",
+      });
+    }
+  
+    const targetFilepath = pathUtils.join(TARGET_DIR, `${Date.now()}${fileExt}`);
     await pipeline(data.file, fs.createWriteStream(targetFilepath));
   
     let filesToRemove = [targetFilepath];
     try {
-      const mimetype = data.mimetype;
-      if (mimetype !== "application/vnd.openxmlformats-officedocument.wordprocessingml.document") {
-        return reply.status(400).send({
-          error: "File must be of type application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-        });
-      }
-  
-      const convertedFilepath = await docxToPdf(targetFilepath);
+      const convertedFilepath = await convertFn(targetFilepath);
       filesToRemove.push(convertedFilepath);
   
       reply
         .status(200)
         .header("Content-Type", "application/pdf");
+  
+      // Pipe converted content of convertedFilepath to reply
+      await reply.send(fs.createReadStream(convertedFilepath));
+    } catch (err: any) {
+      logger.error(err);
+      reply.status(500).send({ error: err.message });
+    }
+  
+    for (const filepath of filesToRemove) {
+      fsPromises
+        .rm(filepath, {
+          force: true,
+        })
+        .catch((err) => {
+          logger.error(err);
+        });
+    }
+  });
+
+  app.post("/ppt-to-pptx", {}, async (req, reply) => {
+    if (!req.isMultipart) {
+      return reply.status(400).send({
+        error: "Not a multipart request",
+      });
+    }
+  
+    const data = await req.file();
+    if (!data) {
+      return reply.status(400).send({
+        error: "File parameter required",
+      });
+    }
+  
+    const targetFilepath = pathUtils.join(TARGET_DIR, `${Date.now()}.ppt`);
+    await pipeline(data.file, fs.createWriteStream(targetFilepath));
+  
+    let filesToRemove = [targetFilepath];
+    try {
+      const mimetype = data.mimetype;
+      if (mimetype !== "application/vnd.ms-powerpoint") {
+        return reply.status(400).send({
+          error: "File must be of type application/vnd.ms-powerpoint",
+        });
+      }
+  
+      const convertedFilepath = await pptToPptx(targetFilepath);
+      filesToRemove.push(convertedFilepath);
+  
+      reply
+        .status(200)
+        .header("Content-Type", "application/vnd.openxmlformats-officedocument.presentationml.presentation");
+  
+      // Pipe converted content of convertedFilepath to reply
+      await reply.send(fs.createReadStream(convertedFilepath));
+    } catch (err: any) {
+      logger.error(err);
+      reply.status(500).send({ error: err.message });
+    }
+  
+    for (const filepath of filesToRemove) {
+      fsPromises
+        .rm(filepath, {
+          force: true,
+        })
+        .catch((err) => {
+          logger.error(err);
+        });
+    }
+  });
+
+  app.post("/xls-to-xlsx", {}, async (req, reply) => {
+    if (!req.isMultipart) {
+      return reply.status(400).send({
+        error: "Not a multipart request",
+      });
+    }
+  
+    const data = await req.file();
+    if (!data) {
+      return reply.status(400).send({
+        error: "File parameter required",
+      });
+    }
+  
+    const targetFilepath = pathUtils.join(TARGET_DIR, `${Date.now()}.xls`);
+    await pipeline(data.file, fs.createWriteStream(targetFilepath));
+  
+    let filesToRemove = [targetFilepath];
+    try {
+      const mimetype = data.mimetype;
+      if (mimetype !== "application/vnd.ms-excel") {
+        return reply.status(400).send({
+          error: "File must be of type application/vnd.ms-excel",
+        });
+      }
+  
+      const convertedFilepath = await xlsToXlsx(targetFilepath);
+      filesToRemove.push(convertedFilepath);
+  
+      reply
+        .status(200)
+        .header("Content-Type", "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
   
       // Pipe converted content of convertedFilepath to reply
       await reply.send(fs.createReadStream(convertedFilepath));


### PR DESCRIPTION
[V] tested locally

Supports:
## API Usage

### Convert DOC to DOCX
POST /doc-to-docx
Content-Type: multipart/form-data
file=@document.doc

### Convert to PDF (from DOCX or PPTX)
POST /to-pdf
Content-Type: multipart/form-data
file=@document.docx or file=@presentation.pptx

### Convert PPT to PPTX
POST /ppt-to-pptx
Content-Type: multipart/form-data
file=@presentation.ppt

### Convert XLS to XLSX
POST /xls-to-xlsx
Content-Type: multipart/form-data
file=@spreadsheet.xls